### PR TITLE
Restore debugger launch of apps and then daemons

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -176,6 +176,13 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            LDFLAGS="-L$pmix_ext_install_libdir $LDFLAGS"])
 
     LIBS="$LIBS -lpmix"
+
+    CPPFLAGS="$CPPFLAGS -I$pmix_ext_install_dir/include"
+    OPAL_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include])
+
+    LDFLAGS="$LDFLAGS -L$pmix_ext_install_libdir"
+    OPAL_WRAPPER_FLAGS_ADD([LDFLAGS], [-L$pmix_ext_install_libdir])
+
     opal_external_pmix_happy=yes
 
     AC_DEFINE_UNQUOTED([OPAL_PMIX_VERSION], [$opal_external_pmix_version_found],

--- a/examples/debuggerd.c
+++ b/examples/debuggerd.c
@@ -273,9 +273,13 @@ int main(int argc, char **argv)
     DEBUG_DESTRUCT_LOCK(&mylock);
 
     /* get the nspace of the job we are to debug - it will be in our JOB info */
+#ifdef PMIX_LOAD_PROCID
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+#else
     PMIX_PROC_CONSTRUCT(&proc);
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_KEYLEN);
     proc.rank = PMIX_RANK_WILDCARD;
+#endif
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_DEBUG_JOB, NULL, 0, &val))) {
         fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - error %s\n",
                 myproc.nspace, myproc.rank,
@@ -384,7 +388,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);  // deliver to the target nspace
     fprintf(stderr, "[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long)pid);
     rc = PMIx_Notify_event(PMIX_ERR_DEBUGGER_RELEASE,
-                           NULL, PMIX_RANGE_LOCAL,
+                           NULL, PMIX_RANGE_CUSTOM,
                            info, ninfo, NULL, NULL);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "%s[%s:%u:%lu] Sending release failed with error %s(%d)\n",

--- a/orte/mca/rmaps/base/base.h
+++ b/orte/mca/rmaps/base/base.h
@@ -123,7 +123,8 @@ ORTE_DECLSPEC int orte_rmaps_base_filter_nodes(orte_app_context_t *app,
                                                opal_list_t *nodes,
                                                bool remove);
 
-ORTE_DECLSPEC int orte_rmaps_base_set_mapping_policy(orte_mapping_policy_t *policy,
+ORTE_DECLSPEC int orte_rmaps_base_set_mapping_policy(orte_job_t *jdata,
+                                                     orte_mapping_policy_t *policy,
                                                      char **device, char *spec);
 ORTE_DECLSPEC int orte_rmaps_base_set_ranking_policy(orte_ranking_policy_t *policy,
                                                      orte_mapping_policy_t mapping,

--- a/orte/mca/rmaps/base/rmaps_base_frame.c
+++ b/orte/mca/rmaps/base/rmaps_base_frame.c
@@ -296,7 +296,7 @@ static int orte_rmaps_base_open(mca_base_open_flag_t flags)
                        "rmaps_base_cpus_per_proc", "rmaps_base_mapping_policy=<obj>:PE=N, default <obj>=NUMA");
     }
 
-    if (ORTE_SUCCESS != (rc = orte_rmaps_base_set_mapping_policy(&orte_rmaps_base.mapping,
+    if (ORTE_SUCCESS != (rc = orte_rmaps_base_set_mapping_policy(NULL, &orte_rmaps_base.mapping,
                                                                  &orte_rmaps_base.device,
                                                                  rmaps_base_mapping_policy))) {
         return rc;
@@ -593,7 +593,8 @@ static int check_modifiers(char *ck, orte_mapping_policy_t *tmp)
     return ORTE_ERR_TAKE_NEXT_OPTION;
 }
 
-int orte_rmaps_base_set_mapping_policy(orte_mapping_policy_t *policy,
+int orte_rmaps_base_set_mapping_policy(orte_job_t *jdata,
+                                       orte_mapping_policy_t *policy,
                                        char **device, char *inspec)
 {
     char *ck;
@@ -681,7 +682,11 @@ int orte_rmaps_base_set_mapping_policy(orte_mapping_policy_t *policy,
                     }
                 }
                 /* now save the pattern */
-                orte_rmaps_base.ppr = strdup(ck);
+                if (NULL == jdata || NULL == jdata->map) {
+                    orte_rmaps_base.ppr = strdup(ck);
+                } else {
+                    jdata->map->ppr = strdup(ck);
+                }
                 ORTE_SET_MAPPING_POLICY(tmp, ORTE_MAPPING_PPR);
                 ORTE_SET_MAPPING_DIRECTIVE(tmp, ORTE_MAPPING_GIVEN);
                 free(spec);
@@ -747,7 +752,11 @@ int orte_rmaps_base_set_mapping_policy(orte_mapping_policy_t *policy,
     }
 
  setpolicy:
-    *policy = tmp;
+    if (NULL == jdata || NULL == jdata->map) {
+        *policy = tmp;
+    } else {
+        jdata->map->mapping = tmp;
+    }
 
     return ORTE_SUCCESS;
 }

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -340,7 +340,7 @@ static void interim(int sd, short args, void *cbdata)
                 rc = ORTE_ERR_BAD_PARAM;
                 goto complete;
             }
-            rc = orte_rmaps_base_set_mapping_policy(&jdata->map->mapping,
+            rc = orte_rmaps_base_set_mapping_policy(jdata, &jdata->map->mapping,
                                                     NULL, info->value.data.string);
             if (ORTE_SUCCESS != rc) {
                 goto complete;

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -565,7 +565,7 @@ static void _query(int sd, short args, void *cbdata)
     pmix_data_array_t *darray;
     pmix_proc_info_t *procinfo;
     pmix_info_t *info;
-    pmix_status_t ret;
+    pmix_status_t ret = PMIX_SUCCESS;
     opal_ds_info_t *kv;
     orte_jobid_t jobid;
     orte_job_t *jdata;
@@ -785,14 +785,14 @@ static void _query(int sd, short args, void *cbdata)
                     }
                 }
                 if (ORTE_JOBID_INVALID == jobid) {
-                    rc = ORTE_ERR_BAD_PARAM;
+                    ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
                 /* construct a list of values with opal_proc_info_t
                  * entries for each proc in the indicated job */
                 jdata = orte_get_job_data_object(jobid);
                 if (NULL == jdata) {
-                    rc = ORTE_ERR_NOT_FOUND;
+                    ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
                 /* setup the reply */
@@ -897,9 +897,13 @@ static void _query(int sd, short args, void *cbdata)
             /* convert the list of results to an info array */
             rcd->ninfo = opal_list_get_size(results);
             PMIX_INFO_CREATE(rcd->info, rcd->ninfo);
+            n=0;
+            OPAL_LIST_FOREACH(kv, results, opal_ds_info_t) {
+                PMIX_INFO_XFER(&rcd->info[n], kv->info);
+                n++;
+            }
         }
     }
-
     cd->infocbfunc(ret, rcd->info, rcd->ninfo, cd->cbdata, qrel, rcd);
 }
 

--- a/orte/tools/prun/prun.c
+++ b/orte/tools/prun/prun.c
@@ -649,6 +649,14 @@ int prun(int argc, char *argv[])
         opal_list_append(&tinfo, &ds->super);
     }
 
+    /* check for request to drop a rendezvous file */
+    if (NULL != (param = getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE"))) {
+        ds = OBJ_NEW(opal_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_LAUNCHER_RENDEZVOUS_FILE, param, PMIX_STRING);
+        opal_list_append(&tinfo, &ds->super);
+    }
+
     /* convert to array of info */
     ninfo = opal_list_get_size(&tinfo);
     PMIX_INFO_CREATE(iptr, ninfo);


### PR DESCRIPTION
Fix the mapping code to handle job-level directives on mapping
algorithms. Correctly specify the range of the debugger release.
Temporarily force the cospawn flag to false in the debugger example.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>