### PR TITLE
Continue work on support for indirect launch

### DIFF
--- a/orte/mca/iof/hnp/iof_hnp.c
+++ b/orte/mca/iof/hnp/iof_hnp.c
@@ -422,6 +422,16 @@ static void hnp_complete(const orte_job_t *jdata)
     OPAL_LIST_FOREACH_SAFE(proct, next, &mca_iof_hnp_component.procs, orte_iof_proc_t) {
         if (jdata->jobid == proct->name.jobid) {
             opal_list_remove_item(&mca_iof_hnp_component.procs, &proct->super);
+            if (NULL != proct->revstdout) {
+                orte_iof_base_static_dump_output(proct->revstdout);
+                OBJ_RELEASE(proct->revstdout);
+            }
+            proct->revstdout = NULL;
+            if (NULL != proct->revstderr) {
+                orte_iof_base_static_dump_output(proct->revstderr);
+                OBJ_RELEASE(proct->revstderr);
+            }
+            proct->revstderr = NULL;
             OBJ_RELEASE(proct);
         }
     }

--- a/orte/mca/iof/hnp/iof_hnp_read.c
+++ b/orte/mca/iof/hnp/iof_hnp_read.c
@@ -317,9 +317,11 @@ void orte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         if (rev->tag & ORTE_IOF_STDOUT) {
             orte_iof_base_static_dump_output(proct->revstdout);
             OBJ_RELEASE(proct->revstdout);
+            proct->revstdout = NULL;
         } else if (rev->tag & ORTE_IOF_STDERR) {
             orte_iof_base_static_dump_output(proct->revstderr);
             OBJ_RELEASE(proct->revstderr);
+            proct->revstderr = NULL;
         }
         /* check to see if they are all done */
         if (NULL == proct->revstdout &&

--- a/orte/tools/prun/prun.c
+++ b/orte/tools/prun/prun.c
@@ -649,6 +649,16 @@ int prun(int argc, char *argv[])
         opal_list_append(&tinfo, &ds->super);
     }
 
+    /* if we were launched by a debugger, then we need to have
+     * notification of our termination sent */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        ds = OBJ_NEW(opal_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = false;
+        PMIX_INFO_LOAD(ds->info, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
+        opal_list_append(&tinfo, &ds->super);
+    }
+
 #ifdef PMIX_LAUNCHER_RENDEZVOUS_FILE
     /* check for request to drop a rendezvous file */
     if (NULL != (param = getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE"))) {
@@ -1007,7 +1017,7 @@ int prun(int argc, char *argv[])
                     ninfo = myinfo.info[n].value.data.darray->size;
                     for (m=0; m < ninfo; m++) {
                         ds = OBJ_NEW(opal_ds_info_t);
-                        ds->info = &iptr[n];
+                        ds->info = &iptr[m];
                         opal_list_append(&job_info, &ds->super);
                     }
                     free(myinfo.info[n].value.data.darray);  // protect the info structs


### PR DESCRIPTION
Implement support by which a debugger can launch prun, pass directives
to it, and then have prun execute an application. Still need to work on
completing IOF of application thru prun to debugger.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>