### PR TITLE
Add support for generating context ID

### DIFF
--- a/orte/mca/grpcomm/base/base.h
+++ b/orte/mca/grpcomm/base/base.h
@@ -72,6 +72,7 @@ typedef struct {
     opal_list_t ongoing;
     opal_hash_table_t sig_table;
     char *transports;
+    size_t context_id;
 } orte_grpcomm_base_t;
 
 ORTE_DECLSPEC extern orte_grpcomm_base_t orte_grpcomm_base;
@@ -82,7 +83,7 @@ ORTE_DECLSPEC int orte_grpcomm_API_xcast(orte_grpcomm_signature_t *sig,
                                          opal_buffer_t *buf);
 
 ORTE_DECLSPEC int orte_grpcomm_API_allgather(orte_grpcomm_signature_t *sig,
-                                             opal_buffer_t *buf,
+                                             opal_buffer_t *buf, int mode,
                                              orte_grpcomm_cbfunc_t cbfunc,
                                              void *cbdata);
 

--- a/orte/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/orte/mca/grpcomm/base/grpcomm_base_frame.c
@@ -95,6 +95,7 @@ static int orte_grpcomm_base_open(mca_base_open_flag_t flags)
     OBJ_CONSTRUCT(&orte_grpcomm_base.ongoing, opal_list_t);
     OBJ_CONSTRUCT(&orte_grpcomm_base.sig_table, opal_hash_table_t);
     opal_hash_table_init(&orte_grpcomm_base.sig_table, 128);
+    orte_grpcomm_base.context_id = 0;
 
     return mca_base_framework_components_open(&orte_grpcomm_base_framework, flags);
 }

--- a/orte/mca/grpcomm/grpcomm.h
+++ b/orte/mca/grpcomm/grpcomm.h
@@ -121,7 +121,7 @@ typedef int (*orte_grpcomm_base_module_xcast_fn_t)(orte_vpid_t *vpids,
  * NOTE: this is a non-blocking call. The callback function cached in
  * the orte_grpcomm_coll_t will be invoked upon completion. */
 typedef int (*orte_grpcomm_base_module_allgather_fn_t)(orte_grpcomm_coll_t *coll,
-                                                       opal_buffer_t *buf);
+                                                       opal_buffer_t *buf, int mode);
 
 /*
  * Ver 3.0 - internal modules
@@ -156,7 +156,7 @@ typedef int (*orte_grpcomm_base_API_xcast_fn_t)(orte_grpcomm_signature_t *sig,
  * NOTE: this is a non-blocking call. The provided callback function
  * will be invoked upon completion. */
 typedef int (*orte_grpcomm_base_API_allgather_fn_t)(orte_grpcomm_signature_t *sig,
-                                                    opal_buffer_t *buf,
+                                                    opal_buffer_t *buf, int mode,
                                                     orte_grpcomm_cbfunc_t cbfunc,
                                                     void *cbdata);
 typedef struct {

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -112,7 +112,8 @@ static pmix_server_module_t pmix_server = {
     .tool_connected = pmix_tool_connected_fn,
     .log = pmix_server_log_fn,
     .allocate = pmix_server_alloc_fn,
-    .job_control = pmix_server_job_ctrl_fn
+    .job_control = pmix_server_job_ctrl_fn,
+    .group = pmix_server_group_fn
 };
 
 void pmix_server_register_params(void)
@@ -848,6 +849,7 @@ OBJ_CLASS_INSTANCE(pmix_server_req_t,
 static void mdcon(orte_pmix_mdx_caddy_t *p)
 {
     p->sig = NULL;
+    p->buf = NULL;
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }
@@ -855,6 +857,9 @@ static void mddes(orte_pmix_mdx_caddy_t *p)
 {
     if (NULL != p->sig) {
         OBJ_RELEASE(p->sig);
+    }
+    if (NULL != p->buf) {
+        OBJ_RELEASE(p->buf);
     }
 }
 OBJ_CLASS_INSTANCE(orte_pmix_mdx_caddy_t,

--- a/orte/orted/pmix/pmix_server_fence.c
+++ b/orte/orted/pmix/pmix_server_fence.c
@@ -122,7 +122,7 @@ pmix_status_t pmix_server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* pass it to the global collective algorithm */
     /* pass along any data that was collected locally */
-    if (ORTE_SUCCESS != (rc = orte_grpcomm.allgather(cd->sig, buf, pmix_server_release, cd))) {
+    if (ORTE_SUCCESS != (rc = orte_grpcomm.allgather(cd->sig, buf, 0, pmix_server_release, cd))) {
         ORTE_ERROR_LOG(rc);
         OBJ_RELEASE(buf);
         return PMIX_ERROR;

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -1307,3 +1307,108 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor,
 
     return PMIX_OPERATION_SUCCEEDED;
 }
+
+static void relcb(void *cbdata)
+{
+    orte_pmix_mdx_caddy_t *cd=(orte_pmix_mdx_caddy_t*)cbdata;
+
+    OBJ_RELEASE(cd);
+}
+static void group_release(int status, opal_buffer_t *buf, void *cbdata)
+{
+    orte_pmix_mdx_caddy_t *cd = (orte_pmix_mdx_caddy_t*)cbdata;
+    int32_t cnt;
+    int rc, mode;
+    pmix_status_t ret;
+    size_t cid, ninfo = 0;
+    pmix_info_t *info = NULL;
+
+    ORTE_ACQUIRE_OBJECT(cd);
+
+    if (ORTE_SUCCESS != status) {
+        rc = status;
+        goto complete;
+    }
+
+    /* first thing in the payload is the mode */
+    cnt = 1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buf, &mode, &cnt, OPAL_INT))) {
+        ORTE_ERROR_LOG(rc);
+        goto complete;
+    }
+
+    /* if a context id was provided, get it */
+    if (1 == mode) {
+        cnt = 1;
+        if (OPAL_SUCCESS != (rc = opal_dss.unpack(buf, &cid, &cnt, OPAL_SIZE))) {
+            ORTE_ERROR_LOG(rc);
+            goto complete;
+        }
+        ninfo = 1;
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[0], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_SIZE);
+    }
+
+  complete:
+    ret = opal_pmix_convert_rc(rc);
+    /* return to the local procs in the collective */
+    if (NULL != cd->infocbfunc) {
+        cd->infocbfunc(ret, info, ninfo, cd->cbdata, relcb, cd);
+    } else {
+        if (NULL != info) {
+            PMIX_INFO_FREE(info, ninfo);
+        }
+    }
+}
+
+pmix_status_t pmix_server_group_fn(pmix_group_operation_t op,
+                                   const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t directives[], size_t ndirs,
+                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    orte_pmix_mdx_caddy_t *cd;
+    int rc;
+    size_t i, mode = 0;
+
+    if (PMIX_GROUP_CONSTRUCT == op) {
+        /* check the directives for a request to assign a context id */
+        for (i=0; i < ndirs; i++) {
+            if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_ASSIGN_CONTEXT_ID)) {
+                if (PMIX_INFO_TRUE(&directives[i])) {
+                    mode = 1;
+                }
+                break;
+            }
+        }
+    }
+
+    cd = OBJ_NEW(orte_pmix_mdx_caddy_t);
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+
+   /* compute the signature of this collective */
+    if (NULL != procs) {
+        cd->sig = OBJ_NEW(orte_grpcomm_signature_t);
+        cd->sig->sz = nprocs;
+        cd->sig->signature = (orte_process_name_t*)malloc(cd->sig->sz * sizeof(orte_process_name_t));
+        memset(cd->sig->signature, 0, cd->sig->sz * sizeof(orte_process_name_t));
+        for (i=0; i < nprocs; i++) {
+            OPAL_PMIX_CONVERT_PROCT(rc, &cd->sig->signature[i], &procs[i]);
+            if (OPAL_SUCCESS != rc) {
+                OPAL_ERROR_LOG(rc);
+                OBJ_RELEASE(cd);
+                return PMIX_ERR_BAD_PARAM;
+            }
+        }
+    }
+    cd->buf = OBJ_NEW(opal_buffer_t);
+
+    /* pass it to the global collective algorithm */
+    if (ORTE_SUCCESS != (rc = orte_grpcomm.allgather(cd->sig, cd->buf, mode,
+                                                     group_release, cd))) {
+        ORTE_ERROR_LOG(rc);
+        OBJ_RELEASE(cd);
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -119,7 +119,9 @@ OBJ_CLASS_DECLARATION(orte_pmix_server_op_caddy_t);
 typedef struct {
     opal_object_t super;
     orte_grpcomm_signature_t *sig;
+    opal_buffer_t *buf;
     pmix_modex_cbfunc_t cbfunc;
+    pmix_info_cbfunc_t infocbfunc;
     void *cbdata;
 } orte_pmix_mdx_caddy_t;
 OBJ_CLASS_DECLARATION(orte_pmix_mdx_caddy_t);
@@ -258,6 +260,12 @@ extern pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor,
                                              const pmix_proc_t targets[], size_t ntargets,
                                              const pmix_info_t directives[], size_t ndirs,
                                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op,
+                                          const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t directives[], size_t ndirs,
+                                          pmix_info_cbfunc_t cbfunc, void *cbdata);
+
 
 /* declare the RML recv functions for responses */
 extern void pmix_server_launch_resp(int status, orte_process_name_t* sender,


### PR DESCRIPTION
If PMIx Group construct asks us to generate a context ID for the new
group, then do so within the context of the required fence operation.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>