### PR TITLE
Ensure that PRRTE builds against all PMIx versions

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -117,7 +117,8 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                                                ], [])],
                               [AC_MSG_RESULT([found])
                                opal_external_pmix_version=4x
-                               opal_external_pmix_version_found=1],
+                               opal_external_pmix_version_found=4
+                               opal_prun_happy=yes],
                               [AC_MSG_RESULT([not found])])])
 
     AS_IF([test "$opal_external_pmix_version_found" = "0"],
@@ -130,7 +131,8 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                                                ], [])],
                               [AC_MSG_RESULT([found])
                                opal_external_pmix_version=3x
-                               opal_external_pmix_version_found=1],
+                               opal_external_pmix_version_found=3
+                               opal_prun_happy=yes],
                               [AC_MSG_RESULT([not found])])])
 
     AS_IF([test "$opal_external_pmix_version_found" = "0"],
@@ -143,7 +145,7 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                                               ], [])],
                              [AC_MSG_RESULT([found])
                               opal_external_pmix_version=2x
-                              opal_external_pmix_version_found=1
+                              opal_external_pmix_version_found=2
                               opal_prun_happy=yes],
                              [AC_MSG_RESULT([not found])])])
 

--- a/opal/pmix/pmix-internal.h
+++ b/opal/pmix/pmix-internal.h
@@ -472,6 +472,37 @@ OPAL_DECLSPEC int opal_pmix_register_cleanup(char *path,
                                              bool ignore,
                                              bool jobscope);
 
+/* protect against early versions of PMIx */
+#ifndef PMIX_VALUE_UNLOAD
+pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data, size_t *sz);
+#define PMIX_VALUE_UNLOAD(r, k, d, s)      \
+    (r) = pmix_value_unload((k), (d), (s))
+#endif
+
+#ifndef PMIX_DATA_BUTTER_LOAD
+#define PMIX_DATA_BUFFER_LOAD(b, d, s)          \
+    do {                                        \
+        (b)->base_ptr = (char*)(d);             \
+        (b)->pack_ptr = (b)->base_ptr + (s);    \
+        (b)->unpack_ptr = (b)->base_ptr;        \
+        (b)->bytes_allocated = (s);             \
+        (b)->bytes_used = (s);                  \
+    } while(0)
+#endif
+
+#ifndef PMIX_DATA_BUFFER_UNLOAD
+#define PMIX_DATA_BUFFER_UNLOAD(b, d, s)    \
+    do {                                    \
+        (d) = (b)->base_ptr;                \
+        (s) = (b)->bytes_used;              \
+        (b)->base_ptr = NULL;               \
+    } while(0)
+#endif
+
+#ifndef PMIX_OPERATION_IN_PROGRESS
+#define PMIX_OPERATION_IN_PROGRESS  -156
+#endif
+
 END_C_DECLS
 
 #endif

--- a/opal/pmix/pmix.c
+++ b/opal/pmix/pmix.c
@@ -488,6 +488,7 @@ void opal_pmix_value_load(pmix_value_t *v,
             v->data.pinfo->exit_code = kv->data.pinfo.exit_code;
             v->data.pinfo->state = opal_pmix_convert_state(kv->data.pinfo.state);
             break;
+#if OPAL_PMIX_VERSION >= 3
         case OPAL_ENVAR:
             v->type = PMIX_ENVAR;
             PMIX_ENVAR_CONSTRUCT(&v->data.envar);
@@ -499,6 +500,7 @@ void opal_pmix_value_load(pmix_value_t *v,
             }
             v->data.envar.separator = kv->data.envar.separator;
             break;
+#endif
         default:
             /* silence warnings */
             break;
@@ -684,6 +686,7 @@ int opal_pmix_value_unload(opal_value_t *kv,
         kv->data.pinfo.exit_code = v->data.pinfo->exit_code;
         kv->data.pinfo.state = opal_pmix_convert_pstate(v->data.pinfo->state);
         break;
+#if OPAL_PMIX_VERSION >= 3
     case PMIX_ENVAR:
         kv->type = OPAL_ENVAR;
         OBJ_CONSTRUCT(&kv->data.envar, opal_envar_t);
@@ -695,6 +698,7 @@ int opal_pmix_value_unload(opal_value_t *kv,
         }
         kv->data.envar.separator = v->data.envar.separator;
         break;
+#endif
     default:
         /* silence warnings */
         rc = OPAL_ERROR;
@@ -734,6 +738,9 @@ int opal_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
 
     OPAL_PMIX_CONSTRUCT_LOCK(&lk);
 
+#if OPAL_PMIX_VERSION < 3
+    return OPAL_ERR_NOT_SUPPORTED;
+#else
     if (ignore) {
         /* they want this path ignored */
         PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_CLEANUP_IGNORE, path, PMIX_STRING);
@@ -751,6 +758,7 @@ int opal_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
             ++ninfo;
         }
     }
+#endif
 
     /* if they want this applied to the job, then indicate so */
     if (jobscope) {
@@ -781,7 +789,11 @@ static void dsicon(opal_ds_info_t *p)
 {
     PMIX_PROC_CONSTRUCT(&p->source);
     p->info = NULL;
+#if OPAL_PMIX_VERSION < 3
+    p->persistence = PMIX_PERSIST_INDEF;
+#else
     p->persistence = PMIX_PERSIST_INVALID;
+#endif
 }
 OBJ_CLASS_INSTANCE(opal_ds_info_t,
                    opal_list_item_t,

--- a/orte/mca/iof/hnp/iof_hnp.c
+++ b/orte/mca/iof/hnp/iof_hnp.c
@@ -621,6 +621,7 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
     return;
 }
 
+#if OPAL_PMIX_VERSION >= 3
 static void lkcbfunc(pmix_status_t status, void *cbdata)
 {
     opal_pmix_lock_t *lk = (opal_pmix_lock_t*)cbdata;
@@ -629,14 +630,16 @@ static void lkcbfunc(pmix_status_t status, void *cbdata)
     lk->status = opal_pmix_convert_status(status);
     OPAL_PMIX_WAKEUP_THREAD(lk);
 }
+#endif
 
 static int hnp_output(const orte_process_name_t* peer,
                       orte_iof_tag_t source_tag,
                       const char *msg)
 {
+#if OPAL_PMIX_VERSION >= 3
+    pmix_iof_channel_t pchan;
     pmix_proc_t source;
     pmix_byte_object_t bo;
-    pmix_iof_channel_t pchan;
     opal_pmix_lock_t lock;
     pmix_status_t rc;
     int ret;
@@ -674,13 +677,15 @@ static int hnp_output(const orte_process_name_t* peer,
         OPAL_PMIX_DESTRUCT_LOCK(&lock);
         return ret;
     } else {
+#endif
         /* output this to our local output */
         if (ORTE_IOF_STDOUT & source_tag || orte_xml_output) {
             orte_iof_base_write_output(peer, source_tag, (const unsigned char*)msg, strlen(msg), orte_iof_base.iof_write_stdout->wev);
         } else {
             orte_iof_base_write_output(peer, source_tag, (const unsigned char*)msg, strlen(msg), orte_iof_base.iof_write_stderr->wev);
         }
+#if OPAL_PMIX_VERSION >= 3
     }
-
+#endif
     return ORTE_SUCCESS;
 }

--- a/orte/mca/iof/hnp/iof_hnp_read.c
+++ b/orte/mca/iof/hnp/iof_hnp_read.c
@@ -95,6 +95,7 @@ void orte_iof_hnp_stdin_cb(int fd, short event, void *cbdata)
     }
 }
 
+#if OPAL_PMIX_VERSION >= 3
 static void lkcbfunc(pmix_status_t status, void *cbdata)
 {
     opal_pmix_lock_t *lk = (opal_pmix_lock_t*)cbdata;
@@ -103,6 +104,7 @@ static void lkcbfunc(pmix_status_t status, void *cbdata)
     lk->status = opal_pmix_convert_status(status);
     OPAL_PMIX_WAKEUP_THREAD(lk);
 }
+#endif
 
 /* this is the read handler for my own child procs. In this case,
  * the data is going nowhere - I just output it myself
@@ -262,6 +264,7 @@ void orte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                      ORTE_NAME_PRINT(&proct->name), (int)numbytes,
                                      ORTE_NAME_PRINT(&sink->daemon)));
+            #if OPAL_PMIX_VERSION >= 3
                 /* don't pass down zero byte blobs */
                 if (0 < numbytes) {
                     pmix_proc_t source;
@@ -297,6 +300,9 @@ void orte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
                     }
                     OPAL_PMIX_DESTRUCT_LOCK(&lock);
                 }
+            #else
+                orte_iof_hnp_send_data_to_endpoint(&sink->daemon, &proct->name, rev->tag, data, numbytes);
+            #endif
                 if (sink->exclusive) {
                     exclusive = true;
                 }

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -107,6 +107,8 @@ typedef struct {
     opal_pmix_lock_t lock;
 } orte_odls_jcaddy_t;
 
+
+#if OPAL_PMIX_VERSION >= 3
 static void setup_cbfunc(pmix_status_t status,
                          pmix_info_t info[], size_t ninfo,
                          void *provided_cbdata,
@@ -168,6 +170,8 @@ static void setup_cbfunc(pmix_status_t status,
     OPAL_PMIX_WAKEUP_THREAD(&cd->lock);
 
 }
+#endif
+
 /* IT IS CRITICAL THAT ANY CHANGE IN THE ORDER OF THE INFO PACKED IN
  * THIS FUNCTION BE REFLECTED IN THE CONSTRUCT_CHILD_LIST PARSER BELOW
 */
@@ -184,7 +188,7 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
     void *nptr;
     uint32_t key;
     char *nidmap;
-    orte_proc_t *dmn, *proc, *pptr;
+    orte_proc_t *dmn, *proc;
     pmix_value_t *val = NULL;
     pmix_info_t *info;
     size_t ninfo;
@@ -192,10 +196,13 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
     pmix_data_buffer_t pbuf;
     pmix_status_t ret;
     pmix_byte_object_t pbo;
-    orte_odls_jcaddy_t cd = {0};
-    char **list, **procs, **micro, *tmp, *regex;
-    int i, k;
     orte_node_t *node;
+#if OPAL_PMIX_VERSION >= 3
+    int i, k;
+    char **list, **procs, **micro, *tmp, *regex;
+    orte_odls_jcaddy_t cd = {0};
+    orte_proc_t *pptr;
+#endif
 
     /* get the job data pointer */
     if (NULL == (jdata = orte_get_job_data_object(job))) {
@@ -447,6 +454,7 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
         free(nidmap);
     }
 
+#if OPAL_PMIX_VERSION >= 3
     /* assemble the node and proc map info */
     list = NULL;
     procs = NULL;
@@ -533,6 +541,10 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
         OPAL_PMIX_WAIT_THREAD(&cd.lock);
     }
     OPAL_PMIX_DESTRUCT_LOCK(&cd.lock);
+#else
+    /* move to next stage */
+    ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_SEND_LAUNCH_MSG);
+#endif
     return rc;
 }
 
@@ -556,14 +568,17 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
     orte_app_context_t *app;
     int8_t flag;
     char *ppn;
-    opal_envar_t envt;
     opal_pmix_lock_t lock;
-    pmix_data_buffer_t pbuf;
-    opal_byte_object_t *bo;
     pmix_info_t *info = NULL;
-    size_t m, ninfo=0;
+    size_t ninfo=0;
     pmix_status_t ret;
     pmix_proc_t pproc;
+#if OPAL_PMIX_VERSION >= 3
+    pmix_data_buffer_t pbuf;
+    opal_byte_object_t *bo;
+    size_t m;
+    opal_envar_t envt;
+#endif
 
     OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
                          "%s odls:constructing child list",
@@ -735,6 +750,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
     }
     free(ppn);
 
+#if OPAL_PMIX_VERSION >= 3
     /* unpack the buffer containing any application setup info - there
      * might not be any, so it isn't an error if we don't find things */
     cnt=1;
@@ -807,6 +823,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
             }
         }
     }
+#endif
 
     /* now that the node array in the job map and jdata are completely filled out,.
      * we need to "wireup" the procs to their nodes so other utilities can

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1195,6 +1195,7 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
             }
         }
 
+#if OPAL_PMIX_VERSION >= 3
         /* see if they provided their inventory */
         idx = 1;
         if (ORTE_SUCCESS == opal_dss.unpack(buffer, &bptr, &idx, OPAL_BYTE_OBJECT)) {
@@ -1240,6 +1241,7 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                 OPAL_PMIX_DESTRUCT_LOCK(&lock);
             }
         }
+#endif
 
         /* do we already have this topology from some other node? */
         found = false;

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -234,6 +234,7 @@ opal_cmd_line_init_t orte_cmd_line_opts[] = {
       NULL, OPAL_CMD_LINE_TYPE_NULL, NULL }
 };
 
+#if OPAL_PMIX_VERSION >= 3
 typedef struct {
     opal_pmix_lock_t lock;
     pmix_info_t *info;
@@ -262,6 +263,7 @@ static void infocbfunc(pmix_status_t status,
     }
     OPAL_PMIX_WAKEUP_THREAD(&xfer->lock);
 }
+#endif
 
 int orte_daemon(int argc, char *argv[])
 {
@@ -273,7 +275,9 @@ int orte_daemon(int argc, char *argv[])
     pmix_value_t val;
     pmix_proc_t proc;
     pmix_status_t prc;
+#if OPAL_PMIX_VERSION >= 3
     myxfer_t xfer;
+#endif
     pmix_data_buffer_t pbuf;
     pmix_byte_object_t pbo;
     opal_byte_object_t bo, *boptr;
@@ -949,6 +953,7 @@ int orte_daemon(int argc, char *argv[])
             }
         }
 
+#if OPAL_PMIX_VERSION >= 3
         /* collect our network inventory */
         memset(&xfer, 0, sizeof(myxfer_t));
         OPAL_PMIX_CONSTRUCT_LOCK(&xfer.lock);
@@ -981,6 +986,7 @@ int orte_daemon(int argc, char *argv[])
                 goto DONE;
             }
         }
+#endif
         /* send it to the designated target */
         if (0 > (ret = orte_rml.send_buffer_nb(orte_mgmt_conduit,
                                                &target, buffer,

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -171,7 +171,9 @@ static void interim(int sd, short args, void *cbdata)
 {
     orte_pmix_server_op_caddy_t *cd = (orte_pmix_server_op_caddy_t*)cbdata;
     opal_process_name_t *requestor = &cd->proc;
+#if OPAL_PMIX_VERSION >= 3
     opal_envar_t envar;
+#endif
     orte_job_t *jdata;
     orte_app_context_t *app;
     pmix_app_t *papp;
@@ -263,6 +265,7 @@ static void interim(int sd, short args, void *cbdata)
                     flag = PMIX_INFO_TRUE(info);
                     orte_set_attribute(&app->attributes, ORTE_APP_DEBUGGER_DAEMON,
                                        ORTE_ATTR_GLOBAL, &flag, OPAL_BOOL);
+#if OPAL_PMIX_VERSION >= 3
                 /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
                 /* there can be multiple of these, so we add them to the attribute list */
                 } else if (0 == strcmp(info->key, PMIX_SET_ENVAR)) {
@@ -297,6 +300,7 @@ static void interim(int sd, short args, void *cbdata)
                     /* unrecognized key */
                     orte_show_help("help-orted.txt", "bad-key",
                                    true, "spawn", "application", info->key);
+#endif
                 }
             }
         }
@@ -513,6 +517,7 @@ static void interim(int sd, short args, void *cbdata)
             ORTE_FLAG_SET(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON);
             ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_DEBUGGER);
 
+#if OPAL_PMIX_VERSION >= 3
         /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
         /* there can be multiple of these, so we add them to the attribute list */
         } else if (0 == strcmp(info->key, PMIX_SET_ENVAR)) {
@@ -542,6 +547,7 @@ static void interim(int sd, short args, void *cbdata)
             envar.separator = info->value.data.envar.separator;
             orte_add_attribute(&jdata->attributes, ORTE_JOB_APPEND_ENVAR,
                                ORTE_ATTR_GLOBAL, &envar, OPAL_ENVAR);
+#endif
 
         /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -261,10 +261,12 @@ extern pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor,
                                              const pmix_info_t directives[], size_t ndirs,
                                              pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+#if OPAL_PMIX_VERSION >= 4
 extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op,
                                           const pmix_proc_t procs[], size_t nprocs,
                                           const pmix_info_t directives[], size_t ndirs,
                                           pmix_info_cbfunc_t cbfunc, void *cbdata);
+#endif
 
 
 /* declare the RML recv functions for responses */


### PR DESCRIPTION
Execution issues with some of the earlier versions (e.g., 2.2) that need
to be tracked down, but everything now compiles

Signed-off-by: Ralph Castain <rhc@open-mpi.org>