### PR TITLE
Cleanup fence operations for non-group usage

### DIFF
--- a/examples/log.c
+++ b/examples/log.c
@@ -136,6 +136,7 @@ int main(int argc, char **argv)
     }
 
   fence:
+    fprintf(stderr, "%s:%d Calling Fence\n", myproc.nspace, myproc.rank);
     /* call fence to synchronize with our peers - no need to
      * collect any info as we didn't "put" anything */
     PMIX_INFO_CREATE(info, 1);

--- a/orte/mca/grpcomm/direct/grpcomm_direct.c
+++ b/orte/mca/grpcomm/direct/grpcomm_direct.c
@@ -670,7 +670,7 @@ static void barrier_release(int status, orte_process_name_t* sender,
                             void* cbdata)
 {
     int32_t cnt;
-    int rc, ret;
+    int rc, ret, mode;
     orte_grpcomm_signature_t *sig;
     orte_grpcomm_coll_t *coll;
 
@@ -688,6 +688,13 @@ static void barrier_release(int status, orte_process_name_t* sender,
     /* unpack the return status */
     cnt = 1;
     if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &ret, &cnt, OPAL_INT))) {
+        ORTE_ERROR_LOG(rc);
+        return;
+    }
+
+    /* unpack the mode */
+    cnt = 1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &mode, &cnt, OPAL_INT))) {
         ORTE_ERROR_LOG(rc);
         return;
     }


### PR DESCRIPTION
Strip the mode flag prior to delivery of barrier release to avoid confusing follow-on unpacking operations. Update group_release to be okay if no context id was provided.

Signed-off-by: Ralph H Castain <rhc@open-mpi.org>