### PR TITLE
Do not destroy an opal_byte_object - it is not an OBJECT

### DIFF
--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -1207,7 +1207,7 @@ void pmix_server_log_fn(const pmix_proc_t *client,
         bo.size = pbo.size;
         boptr = &bo;
         opal_dss.pack(buf, &boptr, 1, OPAL_BYTE_OBJECT);
-        OBJ_DESTRUCT(&bo);
+        free(bo.bytes);
         rc = orte_rml.send_buffer_nb(orte_mgmt_conduit,
                                      ORTE_PROC_MY_HNP, buf,
                                      ORTE_RML_TAG_LOGGING,


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>