### PR TITLE
orte/runtime: make orte_job_t a descendant of opal_object_t

### DIFF
--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -727,7 +727,7 @@ static void orte_job_destruct(orte_job_t* job)
 }
 
 OBJ_CLASS_INSTANCE(orte_job_t,
-                   opal_list_item_t,
+                   opal_object_t,
                    orte_job_construct,
                    orte_job_destruct);
 


### PR DESCRIPTION
an orte_job_t is meant to be part of the orte_job_data hash table,
so it does not have to be a descendant of opal_list_item_t (any more).

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>