### PR TITLE
odls/base: plug a memory leak in orte_odls_base_default_construct_chi…

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -762,9 +762,9 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
 
     cnt=1;
     rc = opal_dss.unpack(bptr, &bo, &cnt, OPAL_BYTE_OBJECT);
+    OBJ_RELEASE(bptr);
     if (OPAL_SUCCESS == rc) {
         /* there was setup data - process it */
-        OBJ_RELEASE(bptr);
         PMIX_DATA_BUFFER_LOAD(&pbuf, bo->bytes, bo->size);
         bo->bytes = NULL;
         bo->size = 0;


### PR DESCRIPTION
…ld_list()

always release a temporary opal_buffer_t

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>