### PR TITLE
orted/pmix: correctly plug a memory leak

### DIFF
--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -324,7 +324,6 @@ static void interim(int sd, short args, void *cbdata)
             }
         }
     }
-    PMIX_APP_FREE(cd->apps, cd->napps);
 
     /* transfer the job info across */
     for (m=0; m < cd->ninfo; m++) {


### PR DESCRIPTION
The real memory leak was indeed in pmix, so do not
try to fix it in prrte. This reverts a bit from
pmix/prrte@4c90b07965f053c1a9d9826cd94ff79c4dec5e1a

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>