### PR TITLE
Cleanup the debugger finalize routines

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -142,17 +142,19 @@ static void release_fn(size_t evhdlr_registration_id,
         return;
     }
 
-    /* tell the event handler state machine that we are the last step */
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
-    }
-    fprintf(stderr, "DEBUGGER DAEMON NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
+    fprintf(stderr, "DEBUGGER DAEMON %s NOTIFIED THAT JOB TERMINATED - AFFECTED %s\n", lock->nspace,
             (NULL == affected) ? "NULL" : affected->nspace);
 
     if (found) {
         lock->exit_code = exit_code;
         lock->exit_code_given = true;
     }
+
+    /* tell the event handler state machine that we are the last step */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
     DEBUG_WAKEUP_THREAD(&lock->lock);
 }
 

--- a/examples/debugger/debugger.h
+++ b/examples/debugger/debugger.h
@@ -37,6 +37,7 @@ typedef struct {
     pthread_cond_t cond;
     volatile bool active;
     pmix_status_t status;
+    int count;
 } mylock_t;
 
 #define DEBUG_CONSTRUCT_LOCK(l)                     \
@@ -45,6 +46,7 @@ typedef struct {
         pthread_cond_init(&(l)->cond, NULL);        \
         (l)->active = true;                         \
         (l)->status = PMIX_SUCCESS;                 \
+        (l)->count = 0;                             \
     } while(0)
 
 #define DEBUG_DESTRUCT_LOCK(l)              \

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -727,11 +727,6 @@ void orte_plm_base_registered(int fd, short args, void *cbdata)
     /* update job state */
     jdata->state = caddy->job_state;
 
-   /* if this wasn't a debugger job, then need to init_after_spawn for debuggers */
-    if (!ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_READY_FOR_DEBUGGERS);
-    }
-
     OBJ_RELEASE(caddy);
 }
 

--- a/orte/mca/plm/plm_types.h
+++ b/orte/mca/plm/plm_types.h
@@ -129,9 +129,7 @@ typedef int32_t orte_job_state_t;
 #define ORTE_JOB_STATE_RUNNING                  14  /* all procs have been fork'd */
 #define ORTE_JOB_STATE_SUSPENDED                15  /* job has been suspended */
 #define ORTE_JOB_STATE_REGISTERED               16  /* all procs registered for sync */
-#define ORTE_JOB_STATE_READY_FOR_DEBUGGERS      17  /* job ready for debugger init after spawn */
 #define ORTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE    18  /* all local procs have attempted launch */
-#define ORTE_JOB_STATE_DEBUGGER_DETACH          19  /* a debugger has detached */
 
 /*
  * Define a "boundary" so we can easily and quickly determine

--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -98,7 +98,7 @@ void orte_state_base_activate_job_state(orte_job_t *jdata,
         s = (orte_state_t*)any;
     } else {
         OPAL_OUTPUT_VERBOSE((1, orte_state_base_framework.framework_output,
-                             "ACTIVATE: ANY STATE NOT FOUND"));
+                             "ACTIVATE: JOB STATE %s NOT REGISTERED", orte_job_state_to_str(state)));
         return;
     }
     if (NULL == s->cbfunc) {
@@ -683,11 +683,7 @@ void orte_state_base_track_procs(int fd, short argc, void *cbdata)
         }
         jdata->num_launched++;
         if (jdata->num_launched == jdata->num_procs) {
-            if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-                ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_READY_FOR_DEBUGGERS);
-            } else {
-                ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_RUNNING);
-            }
+            ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_RUNNING);
         }
     } else if (ORTE_PROC_STATE_REGISTERED == state) {
         /* update the proc state */
@@ -994,10 +990,6 @@ void orte_state_base_check_all_complete(int fd, short args, void *cbdata)
                  * is maintained!
                  */
                 if (1 < j) {
-                    if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-                        /* this was a debugger daemon. notify that a debugger has detached */
-                        ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_DEBUGGER_DETACH);
-                    }
                     opal_hash_table_set_value_uint32(orte_job_data, jdata->jobid, NULL);
                     OBJ_RELEASE(jdata);
                 }

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -598,10 +598,7 @@ static void check_complete(int fd, short args, void *cbdata)
         orte_state_base_check_fds(jdata);
     }
 
-    if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        /* this was a debugger daemon. notify that a debugger has detached */
-        ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_DEBUGGER_DETACH);
-    } else if (jdata->state != ORTE_JOB_STATE_NOTIFIED) {
+    if (jdata->state != ORTE_JOB_STATE_NOTIFIED) {
         OPAL_OUTPUT_VERBOSE((2, orte_state_base_framework.framework_output,
                              "%s state:dvm:check_job_completed state is terminated - activating notify",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
@@ -685,7 +682,6 @@ static void dvm_notify(int sd, short args, void *cbdata)
             pname.rank = PMIX_RANK_WILDCARD;
         }
         PMIX_INFO_LOAD(&info[2], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
-
         /* pack the info for sending */
         PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
         OPAL_PMIX_CONVERT_NAME(&pname, ORTE_PROC_MY_NAME);

--- a/orte/util/error_strings.c
+++ b/orte/util/error_strings.c
@@ -261,8 +261,6 @@ const char *orte_job_state_to_str(orte_job_state_t state)
         return "SUSPENDED";
     case ORTE_JOB_STATE_REGISTERED:
         return "SYNC REGISTERED";
-    case ORTE_JOB_STATE_READY_FOR_DEBUGGERS:
-        return "READY FOR DEBUGGERS";
     case ORTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE:
         return "LOCAL LAUNCH COMPLETE";
     case ORTE_JOB_STATE_UNTERMINATED:
@@ -325,8 +323,6 @@ const char *orte_job_state_to_str(orte_job_state_t state)
         return "FAULT TOLERANCE RESTART";
     case ORTE_JOB_STATE_ANY:
         return "ANY";
-    case ORTE_JOB_STATE_DEBUGGER_DETACH:
-        return "DEBUGGER DETACH";
     default:
         return "UNKNOWN STATE!";
     }


### PR DESCRIPTION
Remove some stale process states relating to MPIR. Ensure that tools
properly finalize when started by PRRTE.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>