### PR TITLE
orted: plug a memory leak in the pmix_server_req_t destructor

### DIFF
--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -16,8 +16,8 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -879,6 +879,11 @@ static void rqdes(pmix_server_req_t *p)
     if (NULL != p->jdata) {
         OBJ_RELEASE(p->jdata);
     }
+#ifdef PMIX_CMD_LINE
+    if (NULL != p->cmdline) {
+        free(p->cmdline);
+    }
+#endif
     OBJ_DESTRUCT(&p->msg);
 }
 OBJ_CLASS_INSTANCE(pmix_server_req_t,


### PR DESCRIPTION
Free the cmdline (if PMIX supports it) in the destructor.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>