### PR TITLE
Fix proct usage in query

### DIFF
--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -828,6 +828,7 @@ static void pmix_server_log(int status, orte_process_name_t* sender,
 /****    INSTANTIATE LOCAL OBJECTS    ****/
 static void opcon(orte_pmix_server_op_caddy_t *p)
 {
+    memset(&p->proct, 0, sizeof(pmix_proc_t));
     p->procs = NULL;
     p->nprocs = 0;
     p->eprocs = NULL;

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -723,9 +723,9 @@ static void _cnlk(pmix_status_t status,
 
     /* restart the cnct processor */
     ORTE_PMIX_OPERATION(cd->procs, cd->nprocs, cd->info, cd->ninfo, _cnct, cd->cbfunc, cd->cbdata);
-    /* protect the re-referenced data */
-    cd->procs = NULL;
-    cd->info = NULL;
+    /* we don't need to protect the re-referenced data as
+     * the orte_pmix_server_op_caddy_t does not have
+     * a destructor! */
     OBJ_RELEASE(cd);
     return;
 

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -105,6 +105,7 @@ typedef struct {
     opal_process_name_t proc;
     const char *msg;
     void *server_object;
+    pmix_proc_t proct;
     pmix_proc_t *procs;
     size_t nprocs;
     pmix_proc_t *eprocs;

--- a/orte/orted/pmix/pmix_server_queries.c
+++ b/orte/orted/pmix/pmix_server_queries.c
@@ -107,7 +107,7 @@ static void _query(int sd, short args, void *cbdata)
 
     OBJ_CONSTRUCT(&results, opal_list_t);
 
-    OPAL_PMIX_CONVERT_PROCT(rc, &requestor, cd->procs);
+    OPAL_PMIX_CONVERT_PROCT(rc, &requestor, &cd->proct);
     if (OPAL_SUCCESS != rc) {
         ORTE_ERROR_LOG(rc);
     }
@@ -507,7 +507,7 @@ pmix_status_t pmix_server_query_fn(pmix_proc_t *proct,
 
     /* need to threadshift this request */
     cd = OBJ_NEW(orte_pmix_server_op_caddy_t);
-    cd->procs = proct;
+    memcpy(&cd->proct, proct, sizeof(pmix_proc_t));
     cd->queries = queries;
     cd->nqueries = nqueries;
     cd->infocbfunc = cbfunc;


### PR DESCRIPTION
Add a static pmix_proc_t to the orte_pmix_server_op_caddy_t and use it
to transfer the requestor's ID thru the threadshift as that ID might be
on the stack and isn't guaranteed to be held until the eventual
callback.

Closes #195 

Signed-off-by: Ralph Castain <rhc@pmix.org>