### PR TITLE
Perform a variety of cleanups

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -279,6 +279,10 @@ int main(int argc, char **argv)
     /* only call me back when this specific job terminates */
     PMIX_LOAD_PROCID(&proc, target, PMIX_RANK_WILDCARD);
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
+
+    fprintf(stderr, "[%s:%d:%lu] registering for termination of %s\n", myproc.nspace, myproc.rank,
+            (unsigned long)pid, proc.nspace);
+
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(&code, 1, info, 2,

--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -166,7 +166,7 @@ static void release_fn(size_t evhdlr_registration_id,
         return;
     }
 
-    fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
+    fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED \n",
             (NULL == affected) ? "NULL" : affected->nspace);
     if (found) {
         if (!lock->exit_code_given) {
@@ -227,7 +227,7 @@ static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
     debugger[0].cwd = strdup(cwd);
     /* provide directives so the daemons go where we want, and
      * let the RM know these are debugger daemons */
-    dninfo = 7;
+    dninfo = 8;
     PMIX_INFO_CREATE(dinfo, dninfo);
     PMIX_INFO_LOAD(&dinfo[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
     PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
@@ -236,6 +236,7 @@ static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
     PMIX_INFO_LOAD(&dinfo[4], PMIX_DEBUG_WAITING_FOR_NOTIFY, NULL, PMIX_BOOL);  // tell the daemon that the proc is waiting to be released
     PMIX_INFO_LOAD(&dinfo[5], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
     PMIX_INFO_LOAD(&dinfo[6], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+    PMIX_INFO_LOAD(&dinfo[7], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
     /* spawn the daemons */
     fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
     if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
@@ -415,7 +416,7 @@ int main(int argc, char **argv)
         app[0].cwd = strdup(cwd);
         app[0].maxprocs = 2;
         /* provide job-level directives so the apps do what the user requested */
-        ninfo = 5;
+        ninfo = 6;
         PMIX_INFO_CREATE(info, ninfo);
         PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
         if (stop_on_exec) {
@@ -426,6 +427,7 @@ int main(int argc, char **argv)
         PMIX_INFO_LOAD(&info[2], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
         PMIX_INFO_LOAD(&info[3], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
         PMIX_INFO_LOAD(&info[4], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the job completes
+        PMIX_INFO_LOAD(&info[5], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
 
         /* spawn the job - the function will return when the app
          * has been launched */

--- a/orte/mca/errmgr/default_orted/Makefile.am
+++ b/orte/mca/errmgr/default_orted/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +30,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_default_orted_la_SOURCES = $(sources)
 mca_errmgr_default_orted_la_LDFLAGS = -module -avoid-version
-mca_errmgr_default_orted_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_default_orted_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/dvm/Makefile.am
+++ b/orte/mca/errmgr/dvm/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -30,7 +30,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_dvm_la_SOURCES = $(sources)
 mca_errmgr_dvm_la_LDFLAGS = -module -avoid-version
-mca_errmgr_dvm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_dvm_la_SOURCES =$(sources)

--- a/orte/mca/ess/alps/Makefile.am
+++ b/orte/mca/ess/alps/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,6 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_alps_la_SOURCES = $(sources)
 mca_ess_alps_la_CPPFLAGS = $(ess_alps_CPPFLAGS)
 mca_ess_alps_la_LDFLAGS = -module -avoid-version $(ess_alps_LDFLAGS)
-mca_ess_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
 	$(ess_alps_LDFLAGS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 

--- a/orte/mca/ess/env/Makefile.am
+++ b/orte/mca/ess/env/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,7 +40,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_env_la_SOURCES = $(sources)
 mca_ess_env_la_LDFLAGS = -module -avoid-version
-mca_ess_env_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_env_la_SOURCES =$(sources)

--- a/orte/mca/ess/hnp/Makefile.am
+++ b/orte/mca/ess/hnp/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reseved.
-# Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_hnp_la_SOURCES = $(sources)
 mca_ess_hnp_la_LDFLAGS = -module -avoid-version
-mca_ess_hnp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_hnp_la_SOURCES =$(sources)

--- a/orte/mca/ess/lsf/Makefile.am
+++ b/orte/mca/ess/lsf/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,8 +42,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_lsf_la_SOURCES = $(sources)
 mca_ess_lsf_la_LDFLAGS = -module -avoid-version $(ess_lsf_LDFLAGS)
-mca_ess_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ess_lsf_LIBS)
+mca_ess_lsf_la_LIBADD = $(ess_lsf_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_lsf_la_SOURCES =$(sources)

--- a/orte/mca/ess/slurm/Makefile.am
+++ b/orte/mca/ess/slurm/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,7 +39,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_slurm_la_SOURCES = $(sources)
 mca_ess_slurm_la_LDFLAGS = -module -avoid-version
-mca_ess_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_slurm_la_SOURCES =$(sources)

--- a/orte/mca/ess/tm/Makefile.am
+++ b/orte/mca/ess/tm/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,7 +39,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_tm_la_SOURCES = $(sources)
 mca_ess_tm_la_LDFLAGS = -module -avoid-version
-mca_ess_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_tm_la_SOURCES =$(sources)

--- a/orte/mca/filem/raw/Makefile.am
+++ b/orte/mca/filem/raw/Makefile.am
@@ -11,7 +11,7 @@
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_filem_raw_la_SOURCES = $(sources)
 mca_filem_raw_la_LDFLAGS = -module -avoid-version
-mca_filem_raw_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_filem_raw_la_SOURCES = $(sources)

--- a/orte/mca/grpcomm/direct/Makefile.am
+++ b/orte/mca/grpcomm/direct/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
 #                         reserved.
-# Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -34,7 +34,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_grpcomm_direct_la_SOURCES = $(sources)
 mca_grpcomm_direct_la_LDFLAGS = -module -avoid-version
-mca_grpcomm_direct_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_grpcomm_direct_la_SOURCES =$(sources)

--- a/orte/mca/odls/alps/Makefile.am
+++ b/orte/mca/odls/alps/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2014      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,8 +46,7 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_odls_alps_la_SOURCES = $(sources)
 mca_odls_alps_la_CPPFLAGS = $(odls_alps_CPPFLAGS)
 mca_odls_alps_la_LDFLAGS = -module -avoid-version $(odls_alps_LDFLAGS)
-mca_odls_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(odls_alps_LIBS) \
+mca_odls_alps_la_LIBADD = $(odls_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -770,7 +770,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
         PMIX_DATA_BUFFER_LOAD(&pbuf, bo->bytes, bo->size);
         bo->bytes = NULL;
         bo->size = 0;
-        OBJ_RELEASE(bo);
+        PMIX_BYTE_OBJECT_FREE(bo, 1);
         /* setup the daemon job */
         OPAL_PMIX_CONVERT_NAME(&pproc, ORTE_PROC_MY_NAME);
         /* unpack the number of info structs */

--- a/orte/mca/odls/default/Makefile.am
+++ b/orte/mca/odls/default/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_odls_default_la_SOURCES = $(sources)
 mca_odls_default_la_LDFLAGS = -module -avoid-version
-mca_odls_default_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_odls_default_la_SOURCES =$(sources)

--- a/orte/mca/odls/pspawn/Makefile.am
+++ b/orte/mca/odls/pspawn/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_odls_pspawn_la_SOURCES = $(sources)
 mca_odls_pspawn_la_LDFLAGS = -module -avoid-version
-mca_odls_pspawn_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_odls_pspawn_la_SOURCES =$(sources)

--- a/orte/mca/oob/alps/Makefile.am
+++ b/orte/mca/oob/alps/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, LLC.
 #                         All rights reserved
-# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -36,8 +36,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_oob_alps_la_SOURCES = $(sources)
 mca_oob_alps_la_LDFLAGS = -module -avoid-version
-mca_oob_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ooob_alps_LIBS) \
+mca_oob_alps_la_LIBADD = $(ooob_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 

--- a/orte/mca/oob/tcp/Makefile.am
+++ b/orte/mca/oob/tcp/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, LLC.
 #                         All rights reserved
-# Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -55,7 +55,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_oob_tcp_la_SOURCES = $(sources)
 mca_oob_tcp_la_LDFLAGS = -module -avoid-version
-mca_oob_tcp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_oob_tcp_la_SOURCES = $(sources)

--- a/orte/mca/plm/alps/Makefile.am
+++ b/orte/mca/plm/alps/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,8 +45,7 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_alps_la_SOURCES = $(sources)
 mca_plm_alps_la_CPPFLAGS = $(plm_alps_CPPFLAGS)
 mca_plm_alps_la_LDFLAGS = -module -avoid-version $(plm_alps_LDFLAGS)
-mca_plm_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(plm_alps_LIBS) \
+mca_plm_alps_la_LIBADD = $(plm_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/plm/lsf/Makefile.am
+++ b/orte/mca/plm/lsf/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2008      Institut National de Recherche en Informatique
 #                         et Automatique. All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,8 +46,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_lsf_la_SOURCES = $(sources)
 mca_plm_lsf_la_LDFLAGS = -module -avoid-version $(plm_lsf_LDFLAGS)
-mca_plm_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(plm_lsf_LIBS)
+mca_plm_lsf_la_LIBADD = $(plm_lsf_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_lsf_la_SOURCES = $(sources)

--- a/orte/mca/plm/rsh/Makefile.am
+++ b/orte/mca/plm/rsh/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_rsh_la_SOURCES = $(sources)
 mca_plm_rsh_la_LDFLAGS = -module -avoid-version
-mca_plm_rsh_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_rsh_la_SOURCES =$(sources)

--- a/orte/mca/plm/slurm/Makefile.am
+++ b/orte/mca/plm/slurm/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +42,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_slurm_la_SOURCES = $(sources)
 mca_plm_slurm_la_LDFLAGS = -module -avoid-version
-mca_plm_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_slurm_la_SOURCES =$(sources)

--- a/orte/mca/plm/tm/Makefile.am
+++ b/orte/mca/plm/tm/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -48,8 +48,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_plm_tm_la_SOURCES = $(component_sources)
 mca_plm_tm_la_LDFLAGS = -module -avoid-version $(plm_tm_LDFLAGS)
-mca_plm_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(plm_tm_LIBS)
+mca_plm_tm_la_LIBADD = $(plm_tm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_plm_tm_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/alps/Makefile.am
+++ b/orte/mca/ras/alps/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      UT-Battelle, LLC
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -54,8 +54,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_alps_la_SOURCES = $(component_sources)
 mca_ras_alps_la_LDFLAGS = -module -avoid-version $(ras_alps_LDFLAGS)
-mca_ras_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ras_alps_LIBS)
+mca_ras_alps_la_LIBADD = $(ras_alps_LIBS)
 mca_ras_alps_la_CPPFLAGS = $(ras_alps_CPPFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/orte/mca/ras/gridengine/Makefile.am
+++ b/orte/mca/ras/gridengine/Makefile.am
@@ -13,7 +13,7 @@
 #                         Use is subject to license terms.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +44,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ras_gridengine_la_SOURCES = $(sources)
 mca_ras_gridengine_la_LDFLAGS = -module -avoid-version
-mca_ras_gridengine_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ras_gridengine_la_SOURCES =$(sources)

--- a/orte/mca/ras/lsf/Makefile.am
+++ b/orte/mca/ras/lsf/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,8 +43,7 @@ proxy_SOURCES = \
 mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ras_lsf_la_SOURCES = $(proxy_SOURCES)
-mca_ras_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ras_lsf_LIBS)
+mca_ras_lsf_la_LIBADD = $(ras_lsf_LIBS)
 mca_ras_lsf_la_LDFLAGS = -module -avoid-version $(ras_lsf_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/ras/simulator/Makefile.am
+++ b/orte/mca/ras/simulator/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,7 +36,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_simulator_la_SOURCES = $(component_sources)
 mca_ras_simulator_la_LDFLAGS = -module -avoid-version
-mca_ras_simulator_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_simulator_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/slurm/Makefile.am
+++ b/orte/mca/ras/slurm/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,8 +49,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_slurm_la_SOURCES = $(component_sources)
 mca_ras_slurm_la_LDFLAGS = -module -avoid-version $(ras_slurm_LDFLAGS)
-mca_ras_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ras_slurm_LIBS)
+mca_ras_slurm_la_LIBADD = $(ras_slurm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_slurm_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/tm/Makefile.am
+++ b/orte/mca/ras/tm/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,8 +52,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_tm_la_SOURCES = $(component_sources)
 mca_ras_tm_la_LDFLAGS = -module -avoid-version $(ras_tm_LDFLAGS)
-mca_ras_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
-	$(ras_tm_LIBS)
+mca_ras_tm_la_LIBADD = $(ras_tm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_tm_la_SOURCES = $(lib_sources)

--- a/orte/mca/regx/fwd/Makefile.am
+++ b/orte/mca/regx/fwd/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -29,7 +29,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_regx_fwd_la_SOURCES = $(sources)
 mca_regx_fwd_la_LDFLAGS = -module -avoid-version
-mca_regx_fwd_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_regx_fwd_la_SOURCES = $(sources)

--- a/orte/mca/regx/reverse/Makefile.am
+++ b/orte/mca/regx/reverse/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -29,7 +29,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_regx_reverse_la_SOURCES = $(sources)
 mca_regx_reverse_la_LDFLAGS = -module -avoid-version
-mca_regx_reverse_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_regx_reverse_la_SOURCES = $(sources)

--- a/orte/mca/rmaps/mindist/Makefile.am
+++ b/orte/mca/rmaps/mindist/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +43,6 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_mindist_la_SOURCES = $(sources)
 mca_rmaps_mindist_la_LDFLAGS = -module -avoid-version
-mca_rmaps_mindist_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_mindist_la_SOURCES =$(sources)

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -661,9 +661,9 @@ static void dvm_notify(int sd, short args, void *cbdata)
     pmix_byte_object_t pbo;
     pmix_info_t *info;
     size_t ninfo;
-    pmix_proc_t pname, psource, tgt;
+    pmix_proc_t pname, psource;
     pmix_data_buffer_t pbkt;
-    pmix_data_range_t range = PMIX_RANGE_CUSTOM;
+    pmix_data_range_t range = PMIX_RANGE_SESSION;
     pmix_status_t code, ret;
     char *errmsg = NULL;
 
@@ -701,9 +701,9 @@ static void dvm_notify(int sd, short args, void *cbdata)
     #endif
         /* construct the info to be provided */
         if (NULL == errmsg) {
-            ninfo = 4;
+            ninfo = 3;
         } else {
-            ninfo = 5;
+            ninfo = 4;
         }
         PMIX_INFO_CREATE(info, ninfo);
         /* ensure this only goes to the job terminated event handler */
@@ -719,24 +719,16 @@ static void dvm_notify(int sd, short args, void *cbdata)
             pname.rank = PMIX_RANK_WILDCARD;
         }
         PMIX_INFO_LOAD(&info[2], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
+    #ifdef PMIX_EVENT_TEXT_MESSAGE
+        if (NULL != errmsg) {
+            PMIX_INFO_LOAD(&info[3], PMIX_EVENT_TEXT_MESSAGE, errmsg, PMIX_STRING);
+            free(errmsg);
+        }
+    #endif
 
         /* pack the info for sending */
         PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
         OPAL_PMIX_CONVERT_NAME(&pname, ORTE_PROC_MY_NAME);
-        /* only notify the launcher of this app */
-        if (ORTE_JOBID_INVALID == jdata->launcher) {
-            OPAL_PMIX_CONVERT_JOBID(tgt.nspace, jdata->jobid);
-        } else {
-            OPAL_PMIX_CONVERT_JOBID(tgt.nspace, jdata->launcher);
-        }
-        tgt.rank = 0;
-        PMIX_INFO_LOAD(&info[3], PMIX_EVENT_CUSTOM_RANGE, &tgt, PMIX_PROC);
-    #ifdef PMIX_EVENT_TEXT_MESSAGE
-        if (NULL != errmsg) {
-            PMIX_INFO_LOAD(&info[4], PMIX_EVENT_TEXT_MESSAGE, errmsg, PMIX_STRING);
-            free(errmsg);
-        }
-    #endif
 
         /* pack the status code */
         code = PMIX_ERR_JOB_TERMINATED;

--- a/orte/tools/prun/prun.c
+++ b/orte/tools/prun/prun.c
@@ -1355,27 +1355,7 @@ static int create_app(int argc, char* argv[],
         goto cleanup;
     }
 
-    /* Grab all MCA environment variables */
-    app->app.env = opal_argv_copy(*app_env);
-    for (i=0; NULL != environ[i]; i++) {
-        if (0 == strncmp("PMIX_", environ[i], 5) ||
-            0 == strncmp("OMPI_", environ[i], 5)) {
-            /* check for duplicate in app->env - this
-             * would have been placed there by the
-             * cmd line processor. By convention, we
-             * always let the cmd line override the
-             * environment
-             */
-            param = strdup(environ[i]);
-            value = strchr(param, '=');
-            *value = '\0';
-            value++;
-            opal_setenv(param, value, false, &app->app.env);
-            free(param);
-        }
-    }
-
-    /* set necessary env variables for external usage from tune conf file*/
+    /* set necessary env variables for external usage from tune conf file */
     int set_from_file = 0;
     char **vars = NULL;
     if (OPAL_SUCCESS == mca_base_var_process_env_list_from_file(&vars) &&


### PR DESCRIPTION
Stop relinking every component every time so the build doesn't take so long.

Use correct macro to release pmix_byte_object_t

Let PMIx pickup relevant envars for prun.