### PR TITLE
Implement the backend for forwarding of stdin

### DIFF
--- a/orte/mca/iof/iof.h
+++ b/orte/mca/iof/iof.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -195,6 +195,9 @@ typedef int (*orte_iof_base_output_fn_t)(const orte_process_name_t* peer,
                                          orte_iof_tag_t source_tag,
                                          const char *msg);
 
+typedef int (*orte_iof_base_push_stdin_fn_t)(const orte_process_name_t* dst_name,
+                                             uint8_t *data, size_t sz);
+
 /* Flag that a job is complete */
 typedef void (*orte_iof_base_complete_fn_t)(const orte_job_t *jdata);
 
@@ -210,14 +213,15 @@ typedef int (*orte_iof_base_ft_event_fn_t)(int state);
  *  IOF module.
  */
 struct orte_iof_base_module_2_0_0_t {
-    orte_iof_base_init_fn_t     init;
-    orte_iof_base_push_fn_t     push;
-    orte_iof_base_pull_fn_t     pull;
-    orte_iof_base_close_fn_t    close;
-    orte_iof_base_output_fn_t   output;
-    orte_iof_base_complete_fn_t complete;
-    orte_iof_base_finalize_fn_t finalize;
-    orte_iof_base_ft_event_fn_t ft_event;
+    orte_iof_base_init_fn_t         init;
+    orte_iof_base_push_fn_t         push;
+    orte_iof_base_pull_fn_t         pull;
+    orte_iof_base_close_fn_t        close;
+    orte_iof_base_output_fn_t       output;
+    orte_iof_base_complete_fn_t     complete;
+    orte_iof_base_finalize_fn_t     finalize;
+    orte_iof_base_ft_event_fn_t     ft_event;
+    orte_iof_base_push_stdin_fn_t   push_stdin;
 };
 
 typedef struct orte_iof_base_module_2_0_0_t orte_iof_base_module_2_0_0_t;

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -595,7 +595,6 @@ void orte_plm_base_post_launch(int fd, short args, void *cbdata)
     int32_t rc;
     orte_job_t *jdata;
     orte_state_caddy_t *caddy = (orte_state_caddy_t*)cbdata;
-    orte_process_name_t name;
     orte_timer_t *timer=NULL;
     int ret;
     opal_buffer_t *answer;
@@ -624,23 +623,6 @@ void orte_plm_base_post_launch(int fd, short args, void *cbdata)
     }
     /* update job state */
     caddy->jdata->state = caddy->job_state;
-
-    /* complete wiring up the iof */
-    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                         "%s plm:base:launch wiring up iof for job %s",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_JOBID_PRINT(jdata->jobid)));
-
-    /* push stdin - the IOF will know what to do with the specified target */
-    name.jobid = jdata->jobid;
-    name.vpid = jdata->stdin_target;
-
-    if (ORTE_SUCCESS != (rc = orte_iof.push(&name, ORTE_IOF_STDIN, 0))) {
-        ORTE_ERROR_LOG(rc);
-        ORTE_FORCED_TERMINATE(ORTE_ERROR_DEFAULT_EXIT_CODE);
-        OBJ_RELEASE(caddy);
-        return;
-    }
 
     /* if this isn't a dynamic spawn, just cleanup */
     if (ORTE_JOBID_INVALID == jdata->originator.jobid) {

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -113,6 +113,8 @@ static pmix_server_module_t pmix_server = {
     .log = pmix_server_log_fn,
     .allocate = pmix_server_alloc_fn,
     .job_control = pmix_server_job_ctrl_fn,
+    .iof_pull = pmix_server_iof_pull_fn,
+    .push_stdin = pmix_server_stdin_fn,
 #if PMIX_NUMERIC_VERSION >= 0x00040000
     .group = pmix_server_group_fn
 #endif

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -584,6 +584,9 @@ static void interim(int sd, short args, void *cbdata)
     orte_set_attribute(&jdata->attributes, ORTE_JOB_LAUNCH_PROXY,
                        ORTE_ATTR_GLOBAL, requestor, OPAL_NAME);
 
+    /* indicate that IO is to be forwarded */
+    ORTE_FLAG_SET(jdata, ORTE_JOB_FLAG_FORWARD_OUTPUT);
+
     /* setup a spawn tracker so we know who to call back when this is done
      * and thread-shift the entire thing so it can be safely added to
      * our tracking list */

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -1188,3 +1188,30 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
     return PMIX_SUCCESS;
 }
 #endif
+
+pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_iof_channel_t channels,
+                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix_server_stdin_fn(const pmix_proc_t *source,
+                                   const pmix_proc_t targets[], size_t ntargets,
+                                   const pmix_info_t directives[], size_t ndirs,
+                                   const pmix_byte_object_t *bo,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    orte_process_name_t dst;
+    int rc;
+
+    OPAL_PMIX_CONVERT_PROCT(rc, &dst, &targets[0]);
+    orte_iof.push_stdin(&dst, (uint8_t*)bo->bytes, bo->size);
+
+    if (NULL == bo->bytes || 0 == bo->size) {
+        return PMIX_ERR_IOF_COMPLETE;
+    }
+
+    return PMIX_OPERATION_SUCCEEDED;
+}

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -274,6 +274,17 @@ extern pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor,
                                              const pmix_info_t directives[], size_t ndirs,
                                              pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+extern pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
+                                             const pmix_info_t directives[], size_t ndirs,
+                                             pmix_iof_channel_t channels,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+extern pmix_status_t pmix_server_stdin_fn(const pmix_proc_t *source,
+                                          const pmix_proc_t targets[], size_t ntargets,
+                                          const pmix_info_t directives[], size_t ndirs,
+                                          const pmix_byte_object_t *bo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+
 #if PMIX_NUMERIC_VERSION >= 0x00040000
 extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
                                           const pmix_proc_t procs[], size_t nprocs,


### PR DESCRIPTION
Ensure that we properly forward output from child processes. Accept data
from PMIx server and push to the corresponding target's stdin fd.

Signed-off-by: Ralph Castain <rhc@pmix.org>