### PR TITLE
ras/base: effectively revert d08be7457

### DIFF
--- a/orte/mca/ras/base/base.h
+++ b/orte/mca/ras/base/base.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +56,6 @@ typedef struct orte_ras_base_t {
     orte_ras_base_module_t *active_module;
     int total_slots_alloc;
     int multiplier;
-    bool launch_orted_on_hn;
 } orte_ras_base_t;
 
 ORTE_DECLSPEC extern orte_ras_base_t orte_ras_base;

--- a/orte/mca/ras/base/ras_base_frame.c
+++ b/orte/mca/ras/base/ras_base_frame.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,31 +62,7 @@ static int ras_register(mca_base_register_flag_t flags)
                           NULL, 0, 0,
                           OPAL_INFO_LVL_9,
                           MCA_BASE_VAR_SCOPE_READONLY, &orte_ras_base.multiplier);
-#if SLURM_CRAY_ENV
-    /*
-     * If we are in a Cray-SLURM environment, then we cannot
-     * launch procs local to the HNP. The problem
-     * is the MPI processes launched on the head node (where the
-     * ORTE_PROC_IS_HNP evalues to true) get launched by a daemon
-     * (mpirun) which is not a child of a slurmd daemon.  This
-     * means that any RDMA credentials obtained via the odls/alps
-     * local launcher are incorrect. Test for this condition. If
-     * found, then take steps to ensure we launch a daemon on
-     * the same node as mpirun and that it gets used to fork
-     * local procs instead of mpirun so they get the proper
-     * credential */
 
-    orte_ras_base.launch_orted_on_hn = true;
-#else
-    orte_ras_base.launch_orted_on_hn = false;
-#endif
-
-    mca_base_var_register("orte", "ras", "base", "launch_orted_on_hn",
-                          "Launch an orte daemon on the head node",
-                           MCA_BASE_VAR_TYPE_BOOL,
-                           NULL, 0, 0,
-                           OPAL_INFO_LVL_9,
-                           MCA_BASE_VAR_SCOPE_READONLY, &orte_ras_base.launch_orted_on_hn);
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/ras/base/ras_base_node.c
+++ b/orte/mca/ras/base/ras_base_node.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,24 +85,6 @@ int orte_ras_base_node_insert(opal_list_t* nodes, orte_job_t *jdata)
 
     /* get the hnp node's info */
     hnp_node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0);
-
-    if ((orte_ras_base.launch_orted_on_hn == true) &&
-        (orte_managed_allocation)) {
-        if (NULL != hnp_node) {
-            OPAL_LIST_FOREACH(node, nodes, orte_node_t) {
-                if (orte_ifislocal(node->name)) {
-                    orte_hnp_is_allocated = true;
-                    break;
-                }
-            }
-            if (orte_hnp_is_allocated && !(ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping) &
-                ORTE_MAPPING_NO_USE_LOCAL)) {
-                hnp_node->name = strdup("mpirun");
-                skiphnp = true;
-                ORTE_SET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping, ORTE_MAPPING_NO_USE_LOCAL);
-            }
-        }
-    }
 
     /* cycle through the list */
     while (NULL != (item = opal_list_remove_first(nodes))) {

--- a/orte/util/session_dir.c
+++ b/orte/util/session_dir.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -372,15 +374,6 @@ cleanup:
 int
 orte_session_dir_cleanup(orte_jobid_t jobid)
 {
-    /* special case - if a daemon is colocated with mpirun,
-     * then we let mpirun do the rest to avoid a race
-     * condition. this scenario always results in the rank=1
-     * daemon colocated with mpirun */
-    if (orte_ras_base.launch_orted_on_hn &&
-        ORTE_PROC_IS_DAEMON &&
-        1 == ORTE_PROC_MY_NAME->vpid) {
-        return ORTE_SUCCESS;
-    }
 
     if (!orte_create_session_dirs || orte_process_info.rm_session_dirs ) {
         /* we haven't created them or RM will clean them up for us*/
@@ -489,16 +482,6 @@ orte_session_dir_finalize(orte_process_name_t *proc)
                 opal_output(0, "sess_dir_finalize: proc session dir not empty - leaving");
             }
         }
-    }
-
-    /* special case - if a daemon is colocated with mpirun,
-     * then we let mpirun do the rest to avoid a race
-     * condition. this scenario always results in the rank=1
-     * daemon colocated with mpirun */
-    if (orte_ras_base.launch_orted_on_hn &&
-        ORTE_PROC_IS_DAEMON &&
-        1 == ORTE_PROC_MY_NAME->vpid) {
-        return ORTE_SUCCESS;
     }
 
     opal_os_dirpath_destroy(orte_process_info.job_session_dir,


### PR DESCRIPTION
With the prrte model, the logic to allow for launching
an orted on a node along with mpirun is no longer applicable,
as prun doesn't play the same role as mpirun does in the orted
imbedded in Open MPI model.

Further the option was breaking prun launches on Cray using SLURM.

So, this PR removes launch_orted_on_hn and the associated
MCA parameter.  prun launches on Cray systems now allow
for stdout/stderr to returned to prun.  Behavior on non-Cray
systems remains unchanged since launch_orted_on_hn is
default false on such systems.

An attempt to revert d08be7457 which introduced the launch_orted_on_hn
didn't work, hence the 'by hand' removal in this commit.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>