### PR TITLE
Finish the indirect launch by debugger case

### DIFF
--- a/examples/debugger/debugger.h
+++ b/examples/debugger/debugger.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -79,6 +79,8 @@ typedef struct {
     pmix_status_t status;
     pmix_info_t *info;
     size_t ninfo;
+    pmix_app_t *apps;
+    size_t napps;
 } myquery_data_t;
 
 /* define a structure for releasing when a given

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -603,7 +603,7 @@ int orte_util_pass_node_info(opal_buffer_t *buffer)
         } else {
             /* mark that this was not compressed */
             compressed = false;
-            bo.bytes = bucket.base_ptr;
+            bo.bytes = (uint8_t*)bucket.base_ptr;
             bo.size = bucket.bytes_used;
         }
         /* indicate compression */
@@ -742,7 +742,6 @@ int orte_util_parse_node_info(opal_buffer_t *buf)
     opal_byte_object_t *boptr;
     uint16_t *slots = NULL;
     uint8_t *flags = NULL;
-    uint8_t *topologies = NULL;
     uint8_t *bytes = NULL;
     orte_topology_t *t2;
     hwloc_topology_t topo;
@@ -1025,9 +1024,6 @@ int orte_util_parse_node_info(opal_buffer_t *buf)
     }
     if (NULL != flags) {
         free(flags);
-    }
-    if (NULL != topologies) {
-        free(topologies);
     }
     return rc;
 }


### PR DESCRIPTION
Remove unused variable

Complete the handshake between debugger and launcher. Move the debugger
daemon spawn to an event and switch to a non-blocking spawn call to
avoid deadlock.

Signed-off-by: Ralph Castain <rhc@pmix.org>