### PR TITLE
Support network allocation test operations

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -281,6 +281,13 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
         }
     }
 
+    /* compute the ranks and add the proc objects
+     * to the jdata->procs array */
+    if (ORTE_SUCCESS != (rc = orte_rmaps_base_compute_vpids(jdata))) {
+        ORTE_ERROR_LOG(rc);
+        return rc;
+    }
+
     /* assemble the node and proc map info */
     list = NULL;
     procs = NULL;
@@ -544,20 +551,21 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
             goto REPORT_ERROR;
         }
 
-        if (!ORTE_PROC_IS_HNP) {
+        if (!ORTE_PROC_IS_MASTER) {
             /* assign locations to the procs */
             if (ORTE_SUCCESS != (rc = orte_rmaps_base_assign_locations(jdata))) {
                 ORTE_ERROR_LOG(rc);
                 goto REPORT_ERROR;
             }
+
+            /* compute the ranks and add the proc objects
+             * to the jdata->procs array */
+            if (ORTE_SUCCESS != (rc = orte_rmaps_base_compute_vpids(jdata))) {
+                ORTE_ERROR_LOG(rc);
+                goto REPORT_ERROR;
+            }
         }
 
-        /* compute the ranks and add the proc objects
-         * to the jdata->procs array */
-        if (ORTE_SUCCESS != (rc = orte_rmaps_base_compute_vpids(jdata))) {
-            ORTE_ERROR_LOG(rc);
-            goto REPORT_ERROR;
-        }
         /* and finally, compute the local and node ranks */
         if (ORTE_SUCCESS != (rc = orte_rmaps_base_compute_local_ranks(jdata))) {
             ORTE_ERROR_LOG(rc);

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -375,10 +375,10 @@ int pmix_server_init(void)
         opal_list_append(&ilist, &kv->super);
     }
 
-    /* if we are the HNP or MASTER, then we are a gateway */
-    if (ORTE_PROC_IS_HNP || ORTE_PROC_IS_MASTER) {
+    /* if we are the MASTER, then we are the scheduler */
+    if (ORTE_PROC_IS_MASTER) {
         kv = OBJ_NEW(opal_value_t);
-        kv->key = strdup(PMIX_SERVER_GATEWAY);
+        kv->key = strdup(PMIX_SERVER_SCHEDULER);
         kv->type = OPAL_BOOL;
         kv->data.flag = true;
         opal_list_append(&ilist, &kv->super);


### PR DESCRIPTION
Need to assign proc ranks prior to calling PMIx setup_application so the
network resource allocator knows the ranks in the job. Tag the DVM
master as "scheduler" to enable assignment of resources.

Signed-off-by: Ralph Castain <rhc@pmix.org>